### PR TITLE
Add central package management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.0.2</VersionPrefix>
+        <VersionPrefix>1.0.3</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup Label="Serilog">
+    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft">
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
+  </ItemGroup>
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+</Project>

--- a/LayeredCraft.Logging.CompactJsonFormatter.slnx
+++ b/LayeredCraft.Logging.CompactJsonFormatter.slnx
@@ -8,6 +8,7 @@
   <Folder Name="/Solution Items/">
     <File Path="CLAUDE.md" />
     <File Path="Directory.Build.props" />
+    <File Path="Directory.Packages.props" />
     <File Path="icon.png" />
     <File Path="README.md" />
   </Folder>

--- a/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
+++ b/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
+        <PackageReference Include="Serilog.Formatting.Compact" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj
+++ b/test/LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj
@@ -13,15 +13,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="NSubstitute" Version="5.3.0"/>
-        <PackageReference Include="AwesomeAssertions" Version="9.3.0"/>
-        <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="AwesomeAssertions" />
+        <PackageReference Include="xunit.v3.mtp-v2" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>


### PR DESCRIPTION
## What changed
- Enable NuGet central package management via `Directory.Packages.props`
- Move package versions out of the project files and into the central props file
- Add `Directory.Packages.props` to Solution Items in `LayeredCraft.Logging.CompactJsonFormatter.slnx`
- Include the existing `VersionPrefix` bump (1.0.2 -> 1.0.3)

## Notes
- `Directory.Packages.props` contains only packages actually referenced by this repo.