### PR TITLE
feat(deps): add .NET 11 target support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,13 +11,12 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v6.2
+    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v7.6
     with:
       hasTests: true
-      useMtpRunner: true
-      testDirectory: "test"
       dotnet-version: |
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
     secrets: inherit

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,17 +7,17 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v6.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v7.6
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       hasTests: true
       useMtpRunner: true
-      testDirectory: "test"
       enableCodeCoverage: true
       coverageThreshold: 80
       dotnetVersion: |
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       runCdk: false
     secrets: inherit

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.0.4</VersionPrefix>
+        <VersionPrefix>1.1.0</VersionPrefix>
         <!-- SPDX license identifier for MIT -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,12 @@
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.103" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />

--- a/LayeredCraft.Logging.CompactJsonFormatter.slnx
+++ b/LayeredCraft.Logging.CompactJsonFormatter.slnx
@@ -9,6 +9,7 @@
     <File Path="CLAUDE.md" />
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
+    <File Path="global.json" />
     <File Path="icon.png" />
     <File Path="README.md" />
   </Folder>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
+++ b/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/test/LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj
+++ b/test/LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
Add `net11.0` to the library and test project target frameworks, and align the repository's package and GitHub workflow configuration with that support. This keeps local builds, CI, and package metadata in sync as the project expands framework coverage.

## Changes
- add `net11.0` to `src/LayeredCraft.Logging.CompactJsonFormatter.csproj` and `test/LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj`
- update `.github/workflows/build.yaml` and `.github/workflows/pr-build.yaml` to use `LayeredCraft/devops-templates` `v7.6` and include `.NET 11`
- refresh package versions in `Directory.Packages.props`
- bump `VersionPrefix` to `1.1.0` in `Directory.Build.props`

## Validation
- `dotnet build`
- `dotnet run --project test --framework net8.0`
- `dotnet run --project test --framework net9.0`
- `dotnet run --project test --framework net10.0`
- `dotnet run --project test --framework net11.0`

## Release Notes
Add `.NET 11` targeting support and update the repository's build/test dependencies to match.