### PR TITLE
fix(formatter): use ArgumentNullException.ThrowIfNull for null checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LayeredCraft.Logging.CompactJsonFormatter
 
-[![Build Status](https://github.com/LayeredCraft/compact-json-formatter/actions/workflows/build.yaml/badge.svg)](https://github.com/LayeredCraft/compact-json-formatter/actions/workflows/build.yaml)
+[![Build Status](https://github.com/LayeredCraft/compact-json-formatter/actions/workflows/pr-build.yaml/badge.svg)](https://github.com/LayeredCraft/compact-json-formatter/actions/workflows/pr-build.yaml)
 [![NuGet](https://img.shields.io/nuget/v/LayeredCraft.Logging.CompactJsonFormatter.svg)](https://www.nuget.org/packages/LayeredCraft.Logging.CompactJsonFormatter/)
 [![Downloads](https://img.shields.io/nuget/dt/LayeredCraft.Logging.CompactJsonFormatter.svg)](https://www.nuget.org/packages/LayeredCraft.Logging.CompactJsonFormatter/)
 
@@ -116,8 +116,11 @@ compact-json-formatter/
 │   └── LayeredCraft.Logging.CompactJsonFormatter.Tests.csproj
 ├── .github/
 │   ├── workflows/
-│   │   ├── build.yaml
-│   │   └── pr-build.yaml
+│   │   ├── pr-build.yaml
+│   │   ├── pr-title-check.yaml
+│   │   ├── publish-preview.yaml
+│   │   ├── publish-release.yaml
+│   │   └── release-drafter.yaml
 │   └── dependabot.yml
 ├── Directory.Build.props
 ├── README.md

--- a/src/CompactJsonFormatter.cs
+++ b/src/CompactJsonFormatter.cs
@@ -69,9 +69,9 @@ public sealed class CompactJsonFormatter : ITextFormatter
     /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
     public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
     {
-        if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-        if (output == null) throw new ArgumentNullException(nameof(output));
-        if (valueFormatter == null) throw new ArgumentNullException(nameof(valueFormatter));
+        ArgumentNullException.ThrowIfNull(logEvent);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(valueFormatter);
 
         output.Write($"{{\"{TimestampProperty}\":\"");
         output.Write(logEvent.Timestamp.UtcDateTime.ToString("O"));

--- a/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
+++ b/src/LayeredCraft.Logging.CompactJsonFormatter.csproj
@@ -13,7 +13,7 @@
         <PackageTags>serilog;logging;json;aws;cloudwatch;structured-logging</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Copyright>Copyright (c) 2025 LayeredCraft</Copyright>
+        <Copyright>Copyright (c) 2026 LayeredCraft</Copyright>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Replaces old-style `if (x == null) throw new ArgumentNullException(nameof(x))` pattern with `ArgumentNullException.ThrowIfNull(x)` in `FormatEvent`
- Available in .NET 6+ — all target frameworks (net8–net11) support this

## Test plan

- [ ] PR build passes
- [ ] Merge and verify preview NuGet publish triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)