### PR TITLE
chore(ci): pin all devops-templates workflow references to v8.0

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v7.6
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@main
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}


### PR DESCRIPTION
## Summary

- Pins all `LayeredCraft/devops-templates` workflow references from `@main` to `@v8.0`
- Includes: `pr-build.yaml`, `pr-title-check.yaml`, `publish-preview.yaml`, `publish-release.yaml`, `release-drafter.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)