### PR TITLE
chore(ci): bump devops-templates to v8.2 and update packages

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.0
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,11 @@
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Bumps all devops-templates workflow references from `v8.0` to `v8.2` across all CI/CD workflows. Also updates two NuGet packages:
- `Microsoft.SourceLink.GitHub`: `10.0.202` → `10.0.300`
- `Microsoft.NET.Test.Sdk`: `18.4.0` → `18.5.1`

---

## ✅ Checklist

- [x] My changes build cleanly
- [ ] I've added/updated relevant tests
- [ ] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [ ] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #...

---

## 💬 Notes for Reviewers

CI-only changes. No source code or test changes. Workflows updated: `pr-build`, `pr-title-check`, `publish-preview`, `publish-release`, `release-drafter`.