### PR TITLE
chore(deps): update devops templates and test packages

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v9.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       hasTests: true

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   validate:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v9.0

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v9.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v9.0
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   draft:
-    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v8.2
+    uses: LayeredCraft/devops-templates/.github/workflows/release-drafter.yml@v9.0
     with:
       event_name: ${{ github.event_name }}
       pr_draft: ${{ github.event.pull_request.draft == true }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />


### PR DESCRIPTION
## Summary

Updates the shared LayeredCraft DevOps workflow templates from `v8.2` to `v9.0` and refreshes the Microsoft test platform package versions. This keeps CI, release, preview publishing, and PR validation aligned with the latest shared automation.

## Changes

- Updated reusable GitHub workflow references in `.github/workflows/*` from `LayeredCraft/devops-templates@v8.2` to `@v9.0`.
- Bumped `Microsoft.NET.Test.Sdk` from `18.5.1` to `18.7.0`.
- Bumped `Microsoft.Testing.Extensions.CodeCoverage` from `18.6.2` to `18.8.0`.

## Validation

- Ran `dotnet build` successfully.
