### PR TITLE
ci(github): use NuGet OIDC login workflow refs

### DIFF
--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -13,7 +13,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v9.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@ci/github-nuget-oidc-login
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -8,7 +8,7 @@ permissions: write-all
 
 jobs:
   publish:
-    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v9.0
+    uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@ci/github-nuget-oidc-login
     with:
       solution: LayeredCraft.Logging.CompactJsonFormatter.slnx
       dotnetVersion: |


### PR DESCRIPTION
## Summary

Updates the preview and release publishing workflows to consume the `ci/github-nuget-oidc-login` branch of the shared LayeredCraft DevOps templates. This lets the package publishing workflows validate the NuGet OIDC login changes before switching back to a tagged template release.

## Changes

- Updated `.github/workflows/publish-preview.yaml` to use `LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@ci/github-nuget-oidc-login`.
- Updated `.github/workflows/publish-release.yaml` to use `LayeredCraft/devops-templates/.github/workflows/publish-release.yml@ci/github-nuget-oidc-login`.

## Validation

- Ran `git diff --check` successfully.

## Notes for Reviewers

- These workflow references point to a template feature branch rather than a version tag so the publishing path can validate the OIDC login change.
