### PR TITLE
ci(github): configure dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,15 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 25
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
@@ -6,7 +17,28 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
-      dotnet:
+      dotnet-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
+      dotnet-major:
+        update-types:
+          - "major"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "infrastructure"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'LayeredCraft/compact-json-formatter'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LayeredCraft.Logging.CompactJsonFormatter.slnx
+++ b/LayeredCraft.Logging.CompactJsonFormatter.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/git/">
     <File Path=".github/dependabot.yml" />
+    <File Path=".github/workflows/dependabot-auto-merge.yml" />
     <File Path=".github/workflows/pr-build.yaml" />
     <File Path=".github/workflows/pr-title-check.yaml" />
     <File Path=".github/workflows/publish-preview.yaml" />


### PR DESCRIPTION
## Summary

Updates this repo's Dependabot configuration to match the newer LayeredCraft automation pattern. This adds grouped NuGet updates, GitHub Actions update coverage, and automatic approval/auto-merge for safe Dependabot patch and minor updates.

## Changes

- Expanded `.github/dependabot.yml` with cooldowns, conventional commit metadata, infrastructure multi-ecosystem grouping, separate NuGet minor/patch vs. major groups, and GitHub Actions updates.
- Added `.github/workflows/dependabot-auto-merge.yml` to auto-approve and enable squash auto-merge for Dependabot semver patch/minor PRs only.
- Added the new workflow file to `LayeredCraft.Logging.CompactJsonFormatter.slnx` under `/git/`.

## Validation

- Ran `dotnet restore LayeredCraft.Logging.CompactJsonFormatter.slnx` successfully.
- Ran `dotnet build LayeredCraft.Logging.CompactJsonFormatter.slnx --no-restore` successfully.

## Notes for Reviewers

This repo does not currently have a docs workflow or uv-managed docs dependencies, so no `uv` Dependabot ecosystem entry was added. No conditional Microsoft package ranges were needed for this repo.
